### PR TITLE
HW22

### DIFF
--- a/kubernetes/reddit/mongo-claim-dynamic.yml
+++ b/kubernetes/reddit/mongo-claim-dynamic.yml
@@ -1,0 +1,12 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mongo-pvc-dynamic
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: fast
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/reddit/mongo-claim.yml
+++ b/kubernetes/reddit/mongo-claim.yml
@@ -1,0 +1,11 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mongo-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 15Gi

--- a/kubernetes/reddit/mongo-deployment.yml
+++ b/kubernetes/reddit/mongo-deployment.yml
@@ -1,13 +1,13 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: mongo
   labels:
     app: reddit
     component: mongo
-    comment-db: "true"
     post-db: "true"
+    comment-db: "true"
 spec:
   replicas: 1
   selector:
@@ -20,15 +20,16 @@ spec:
       labels:
         app: reddit
         component: mongo
-        comment-db: "true"
         post-db: "true"
+        comment-db: "true"
     spec:
       containers:
       - image: mongo:3.2
         name: mongo
         volumeMounts:
-        - name: mongo-persistent-storage
+        - name: mongo-gce-pd-storage
           mountPath: /data/db
       volumes:
-      - name: mongo-persistent-storage
-        emptyDir: {}
+      - name: mongo-gce-pd-storage
+        persistentVolumeClaim:
+          claimName: mongo-pvc-dynamic

--- a/kubernetes/reddit/mongo-network-policy.yml
+++ b/kubernetes/reddit/mongo-network-policy.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-db-traffic
+  labels:
+    app: reddit
+spec:
+  podSelector:
+    matchLabels:
+      app: reddit
+      component: mongo
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: reddit
+          component: comment
+    - podSelector:
+        matchLabels:
+          app: reddit
+          component: post

--- a/kubernetes/reddit/mongo-volume.yml
+++ b/kubernetes/reddit/mongo-volume.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: reddit-mongo-disk
+spec:
+  capacity:
+    storage: 25Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  gcePersistentDisk:
+    fsType: "ext4" 
+    pdName: "reddit-mongo-disk"

--- a/kubernetes/reddit/storage-fast.yml
+++ b/kubernetes/reddit/storage-fast.yml
@@ -1,0 +1,8 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: fast
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/kubernetes/reddit/ui-ingress.yml
+++ b/kubernetes/reddit/ui-ingress.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ui
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - secretName: ui-ingress
+  backend:
+    serviceName: ui
+    servicePort: 9292

--- a/kubernetes/reddit/ui-service.yml
+++ b/kubernetes/reddit/ui-service.yml
@@ -9,10 +9,9 @@ metadata:
 spec:
   type: NodePort
   ports:
-    # - nodePort: 32092
-    - port: 9292
-      protocol: TCP
-      targetPort: 9292
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
   selector:
     app: reddit
     component: ui


### PR DESCRIPTION
# Выполнено ДЗ № 22

 - [ +] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Проскейлил в 0 сервис, который следит, чтобы dns-kube подов всегда хватало. Проскейлил в 0 сам kube-dns. Приложение не работает. Вернем kube-dns-autoscale в исходную. Приложение заработало.
 - Изменил тип в ui-service.yml на LoadBalancer. Приложение доступно.
#### Вывод
aleksandr@aleksandr-Lenovo-V310-15IKB:~/MiAA/MinchenkoAA_microservices/kubernetes/reddit$ kubectl get service  -n dev --selector component=ui
NAME   TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
ui     LoadBalancer   10.11.248.218   <pending>     80:32092/TCP   1d
aleksandr@aleksandr-Lenovo-V310-15IKB:~/MiAA/MinchenkoAA_microservices/kubernetes/reddit$ kubectl get service  -n dev --selector component=ui
NAME   TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)        AGE
ui     LoadBalancer   10.11.248.218   34.66.236.125   80:32092/TCP   1d

- Убрал LoadBalancer. Создал ui-ingress.yml. Приложение работает
#### Вывод
 aleksandr@aleksandr-Lenovo-V310-15IKB:~/MiAA/MinchenkoAA_microservices/kubernetes/reddit$ kubectl get ingress -n dev
NAME   HOSTS   ADDRESS          PORTS   AGE
ui     *       35.244.135.193   80      2m

 - Подготовил сертификат и загрузил в кластер. Изменил ui-ingress.yml.
#### Вывод
aleksandr@aleksandr-Lenovo-V310-15IKB:~/MiAA/MinchenkoAA_microservices/kubernetes/reddit$ kubectl get ingress -n dev
NAME   HOSTS   ADDRESS          PORTS     AGE
ui     *       35.244.135.193   80, 443   7m

 - Включил NetworkPolicy
#### Вывод
 gcloud beta container clusters update standard-cluster-1 --zone=us-central1-a --update-addons=NetworkPolicy=ENABLED
Updating standard-cluster-1...done.                                                                                              
Updated [https://container.googleapis.com/v1beta1/projects/docker-231617/zones/us-central1-a/clusters/standard-cluster-1].
To inspect the contents of your cluster, go to: https://console.cloud.google.com/kubernetes/workload_/gcloud/us-central1-a/standard-cluster-1?project=docker-231617

 - Создано хранилище
#### Вывод
aleksandr@aleksandr-Lenovo-V310-15IKB:~/MiAA/MinchenkoAA_microservices/kubernetes/reddit$ kubectl get persistentvolume -n dev
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                   STORAGECLASS   REASON   AGE
pvc-45676311-53bd-11e9-846d-42010a80013c   10Gi       RWO            Delete           Bound       dev/mongo-pvc-dynamic   fast                    1m
pvc-af7206b2-53bc-11e9-846d-42010a80013c   15Gi       RWO            Delete           Bound       dev/mongo-pvc           standard                5m
reddit-mongo-disk                          25Gi       RWO            Retain           Available                                                   6m


## PR checklist
 - [ +] Выставил label с номером домашнего задания
 - [ +] Выставил label с темой домашнего задания